### PR TITLE
Allow the window to be scaled by the user, make config button unavailable if the user does not have write access to the config file

### DIFF
--- a/Logistiek Bonnensorteerder/MainForm.Designer.cs
+++ b/Logistiek Bonnensorteerder/MainForm.Designer.cs
@@ -206,6 +206,9 @@
             // 
             // pdfViewer
             // 
+            this.pdfViewer.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
+            | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
             this.pdfViewer.BackColor = System.Drawing.SystemColors.ControlDark;
             this.pdfViewer.Location = new System.Drawing.Point(312, 12);
             this.pdfViewer.Name = "pdfViewer";
@@ -248,6 +251,7 @@
             // 
             // editConfigButton
             // 
+            this.editConfigButton.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
             this.editConfigButton.Location = new System.Drawing.Point(543, 395);
             this.editConfigButton.Name = "editConfigButton";
             this.editConfigButton.Size = new System.Drawing.Size(24, 23);
@@ -283,9 +287,9 @@
             this.Controls.Add(this.dateTimePicker);
             this.Controls.Add(this.saveButton);
             this.Controls.Add(this.panel1);
-            this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedSingle;
             this.Icon = ((System.Drawing.Icon)(resources.GetObject("$this.Icon")));
             this.MaximizeBox = false;
+            this.MinimumSize = new System.Drawing.Size(595, 469);
             this.Name = "MainForm";
             this.SizeGripStyle = System.Windows.Forms.SizeGripStyle.Hide;
             this.Text = "Bonnard";

--- a/Logistiek Bonnensorteerder/MainForm.cs
+++ b/Logistiek Bonnensorteerder/MainForm.cs
@@ -16,7 +16,7 @@ namespace Logistiek_Bonnensorteerder
         private const string PdfFileExtension = ".pdf";
 
         // Could have taken this from the Datetime object, but we want them to be consistent regardless of culture settings and include a number.
-        private static string[] months = { "01.januari", "02.februari" , "03.maart", "04.april", "05.mei", "06.juni", "07.juli", "08.augustus", "09.september", "10.october", "11.november", "12.december"};
+        private static string[] months = { "01. januari", "02. februari" , "03. maart", "04. april", "05. mei", "06. juni", "07. juli", "08. augustus", "09. september", "10. october", "11. november", "12. december"};
 
         #endregion
 
@@ -48,6 +48,31 @@ namespace Logistiek_Bonnensorteerder
                 ClearPDFPreview();
                 pdfViewer.Show();
                 pdfViewer.Document = PdfiumViewer.PdfDocument.Load(_currentSelectedFile);
+            }
+        }
+
+        public string ConfigFilePath => Path.Combine(AppContext.BaseDirectory, "config.json");
+
+        #endregion
+
+        #region Static Methods
+
+        public static bool CanWriteToFile(string filePath)
+        {
+            try
+            {
+                using (FileStream fs = File.Open(filePath, FileMode.Open, FileAccess.Write))
+                {
+                    return true;
+                }
+            }
+            catch (UnauthorizedAccessException)
+            {
+                return false;
+            }
+            catch (IOException)
+            {
+                return false;
             }
         }
 
@@ -187,16 +212,13 @@ namespace Logistiek_Bonnensorteerder
 
         private void LoadConfigFile()
         {
-            string exeDirectory = AppContext.BaseDirectory;
-            string configPath = Path.Combine(exeDirectory, "config.json");
-
-            if (!File.Exists(configPath))
+            if (!File.Exists(ConfigFilePath))
             {
                 Console.WriteLine("Configuratiebestand niet gevonden!");
                 return;
             }
 
-            string json = File.ReadAllText(configPath);
+            string json = File.ReadAllText(ConfigFilePath);
             ConfigFile = JsonConvert.DeserializeObject<Config>(json);
 
             departmentDropdown.Items.Clear();
@@ -209,6 +231,8 @@ namespace Logistiek_Bonnensorteerder
 
         private void InitializeForm()
         {
+            editConfigButton.Enabled = CanWriteToFile(ConfigFilePath);
+
             saveButton.Enabled = false;
             departmentDropdown.SelectedIndex = 0;
             documentTypeDropdown.SelectedIndex = 0;


### PR DESCRIPTION
## Release Notes:
- Allow scaling the window to increase the PDF preview size
- Make the Config button unavailable if the user does not have write access to the config file

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The "Edit Config" button is now enabled only if the configuration file is writable, improving user feedback and preventing errors.
* **Improvements**
  * The PDF viewer now resizes dynamically with the window for a better viewing experience.
  * The application window enforces a minimum size to ensure proper layout.
  * Month names are now displayed with improved formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->